### PR TITLE
fix(ci): pin release job to Node 22.21 to fix npm global upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,9 +145,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          # Pinned: Node 22.22.2's bundled npm 10.9.5 ships broken in the GH
-          # toolcache (missing `promise-retry`), so `npm install -g` aborts
-          # before we can upgrade for OIDC trusted publishing.
+          # 22.22.2's bundled npm is broken in the GH toolcache (missing `promise-retry`)
           node-version: 22.21.0
 
       - name: Restore node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          # Pinned: Node 22.22.2's bundled npm 10.9.5 ships broken in the GH
+          # toolcache (missing `promise-retry`), so `npm install -g` aborts
+          # before we can upgrade for OIDC trusted publishing.
+          node-version: 22.21.0
 
       - name: Restore node_modules
         uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1


### PR DESCRIPTION
## Summary
The `release` job on main is failing at the *Upgrade npm for OIDC trusted publishing* step: `npm install -g npm@latest` aborts with `Cannot find module 'promise-retry'`. This is a regression in Node 22.22.2's bundled npm 10.9.5 as shipped in the GitHub Actions toolcache — the bundled arborist is missing one of its runtime dependencies, so the in-place npm can't install anything (including itself).

Pin only the release job to `22.21.0` (bundled npm 10.9.3 still works), so it can then upgrade to npm@latest for OIDC trusted publishing. Other jobs (`install`, `lint`, `typescript`, `unit-tests`, `build-package`) all use yarn and are unaffected.

Reference: failing run https://github.com/Andarius/react-native-zstd/actions/runs/25955516695/job/76301446653

## Test plan
- [ ] Merge → CI on main → release job's `Upgrade npm` step passes → publish succeeds